### PR TITLE
Fixed issue where the app would crash if the previously opened folder…

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,7 +187,19 @@ function initialize()
 
 	var lastFolders = settings.get( "folders" )
 
-	if ( lastFolders ) openFolders( lastFolders )
+	//If we have last folders, we need to make sure that the folder still exists before trying to open it
+	if ( lastFolders)
+	{
+		fs.stat(`${lastFolders}`, function(err) {
+			if (!err) {
+				console.log('Opening Last Folders');
+				openFolders( lastFolders )
+			}
+			else if (err.code === 'ENOENT') {
+				console.log(`Last folders: '${lastFolders}' doesn't exist anymore`);
+			}
+		});
+	} 
 
 	expressApp.get( "/", ( request, response ) =>
 	{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "teslacam-browser",
-  "version": "0.0.9",
+  "version": "0.0.91",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Previously the application would close if the previously folder didn't exist. In my case, the app would crash if my USB drive wasn't mapped to the same drive letter (Previously it was F and it mapped as H).

Now the application will check to make sure the folder exists first before opening it. If it doesn't exist it won't attempt to open the folder. If it does though, it will open the folder as normally expected.