### PR TITLE
Fix custom scrub bar growth in edge by shrinking it slightly, closes #38

### DIFF
--- a/app.css
+++ b/app.css
@@ -80,3 +80,8 @@ html, body
   height: auto;
   cursor: pointer;
 }
+.custom-range
+{
+	/* HACK: fix the custom scrub bar slow expansion in Edge */
+	width: 98% !important;
+}


### PR DESCRIPTION
Hack to close #38 by minorly changing the size of the scrub bar so it doesn't auto-grow in edge.